### PR TITLE
Restructure Rust source files

### DIFF
--- a/src/cpio.rs
+++ b/src/cpio.rs
@@ -1,261 +1,57 @@
 use std::ffi::OsString;
-use std::io::{Cursor, Write};
-use std::os::unix::ffi::OsStrExt;
-use std::os::unix::ffi::OsStringExt;
-use std::os::unix::fs::MetadataExt;
 use std::path::{Path, PathBuf};
-use std::{convert::TryInto, fs::File};
 
-use cpio::{newc, write_cpio};
-use lazy_static::lazy_static;
-use tokio::process::Command;
-use walkdir::WalkDir;
+use crate::error::CpioError;
 
-use crate::files::basename;
-
-pub trait ReadSeek: std::io::Read + std::io::Seek {}
-impl<T: std::io::Read + std::io::Seek> ReadSeek for T {}
-
-#[cfg(unix)]
-pub fn make_archive_from_dir<W>(root: &Path, path: &Path, out: W) -> std::io::Result<()>
-where
-    W: Write,
-{
-    path.strip_prefix(&root).unwrap_or_else(|_| {
-        panic!("Path {:?} is not inside root ({:?})", path, &root);
-    });
-
-    let dir = WalkDir::new(path)
-        .sort_by(|a, b| a.file_name().cmp(b.file_name()))
-        .into_iter()
-        .filter_map(|entry| entry.ok())
-        .filter_map(|entry| {
-            let entry_name = entry
-                .path()
-                .strip_prefix(&root)
-                .unwrap_or_else(|_| {
-                    panic!("Path {:?} is not inside root ({:?})", entry.path(), &root)
-                })
-                .to_str()?;
-            let meta = entry.metadata().ok()?;
-            let built = newc::Builder::new(entry_name)
-                .dev_major(0)
-                .rdev_major(0)
-                .gid(1)
-                .uid(0)
-                .ino(meta.ino().try_into().ok()?)
-                .nlink(meta.nlink().try_into().ok()?)
-                .mode(meta.mode())
-                .mtime(1);
-
-            let readable_file: Box<dyn ReadSeek> = if meta.is_file() {
-                Box::new(File::open(entry.path()).ok()?)
-            } else if entry.path().is_symlink() {
-                Box::new(Cursor::new(
-                    entry
-                        .path()
-                        .read_link()
-                        .expect("TOCTTOU: is_symlink said this is a symlink")
-                        .into_os_string()
-                        .into_vec(),
-                ))
-            } else {
-                Box::new(std::io::empty())
-            };
-
-            Some((built, readable_file))
-        });
-    write_cpio(dir, out)?;
-    Ok(())
+#[derive(Debug, Clone)]
+pub struct Cpio {
+    pub size: u64,
+    pub path: CachedPathBuf,
 }
 
-fn make_leader_cpio() -> std::io::Result<Vec<u8>> {
-    let mut leader_cpio = std::io::Cursor::new(vec![]);
-    cpio::write_cpio(
-        vec![
-            // mode for a directory: 0o40000 + 0o00xxx for its permission bits
-            // nlink for directories == the number of things in it plus 2 (., ..)
-            (
-                cpio::newc::Builder::new(".").mode(0o40755).nlink(3),
-                std::io::empty(),
-            ),
-            (
-                cpio::newc::Builder::new("nix").mode(0o40755).nlink(3),
-                std::io::empty(),
-            ),
-            (
-                cpio::newc::Builder::new("nix/store")
-                    .mode(0o40775)
-                    .nlink(2)
-                    .uid(0)
-                    .gid(30000),
-                std::io::empty(),
-            ),
-            (
-                cpio::newc::Builder::new("nix/.nix-netboot-serve-db")
-                    .mode(0o40755)
-                    .nlink(3),
-                std::io::empty(),
-            ),
-            (
-                cpio::newc::Builder::new("nix/.nix-netboot-serve-db/registration")
-                    .mode(0o40755)
-                    .nlink(2),
-                std::io::empty(),
-            ),
-        ]
-        .into_iter(),
-        &mut leader_cpio,
-    )?;
+impl Cpio {
+    pub fn new(path: CachedPathBuf) -> Result<Self, CpioError> {
+        let metadata = std::fs::metadata(&path.0).map_err(|e| CpioError::Fs {
+            ctx: "Reading the CPIO's file metadata",
+            path: path.0.clone(),
+            e,
+        })?;
 
-    Ok(leader_cpio.into_inner())
-}
-
-pub async fn make_registration<W>(path: &Path, dest: &mut W) -> Result<(), MakeRegistrationError>
-where
-    W: Write,
-{
-    let out = Command::new(env!("NIX_STORE_BIN"))
-        .arg("--dump-db")
-        .arg(&path)
-        .output()
-        .await
-        .map_err(MakeRegistrationError::Exec)?;
-    if !out.status.success() {
-        return Err(MakeRegistrationError::DumpDb(out.stderr));
+        Ok(Self {
+            size: metadata.len(),
+            path,
+        })
     }
 
-    let filename = path
-        .file_name()
-        .ok_or(MakeRegistrationError::NoFilename)?
-        .to_str()
-        .ok_or(MakeRegistrationError::FilenameInvalidUtf8)?;
-
-    cpio::write_cpio(
-        vec![(
-            cpio::newc::Builder::new(&format!(
-                "nix/.nix-netboot-serve-db/registration/{}",
-                filename
-            ))
-            .mode(0o0100500)
-            .nlink(1),
-            std::io::Cursor::new(out.stdout),
-        )]
-        .into_iter(),
-        dest,
-    )
-    .map_err(MakeRegistrationError::Io)?;
-
-    Ok(())
+    pub fn path(&self) -> &Path {
+        &self.path.0
+    }
 }
 
-#[derive(Debug, thiserror::Error)]
-pub enum MakeRegistrationError {
-    #[error("Executing a command failed")]
-    Exec(std::io::Error),
+/// A path that points to a cached CPIO.
+#[derive(Debug, Clone)]
+pub struct CachedPathBuf(pub PathBuf);
 
-    #[error("Generating the registration data failed")]
-    DumpDb(Vec<u8>),
+impl CachedPathBuf {
+    pub fn new(src: PathBuf, cache_dir: &Path) -> Result<Self, CpioError> {
+        let cached_path =
+            if let Some(std::path::Component::Normal(pathname)) = src.components().last() {
+                let mut cache_name = OsString::from(pathname);
+                cache_name.push(".cpio.zstd");
 
-    #[error("An ambiguous IO error")]
-    Io(std::io::Error),
+                Ok(cache_dir.join(cache_name))
+            } else {
+                Err(CpioError::Uncachable(format!(
+                    "Cannot calculate a cache path for: {:?}",
+                    src
+                )))
+            };
 
-    #[error("The path submitted appears to have no filename")]
-    NoFilename,
+        cached_path.map(CachedPathBuf)
+    }
 
-    #[error(
-        "The path submitted doesn't seem to be UTF-8, even though Nix probably guarantees this"
-    )]
-    FilenameInvalidUtf8,
-}
-
-pub fn make_load_cpio(paths: &[PathBuf]) -> Result<Vec<u8>, LoadCpioError> {
-    let script = paths
-        .iter()
-        .map(|p| {
-            let mut line =
-                OsString::from("nix-store --load-db < /nix/.nix-netboot-serve-db/registration/");
-            line.push(basename(p).ok_or_else(|| LoadCpioError::NoBasename(p.to_path_buf()))?);
-            Ok(line)
-        })
-        .collect::<Result<Vec<OsString>, LoadCpioError>>()?
-        .into_iter()
-        .fold(OsString::from("#!/bin/sh"), |mut acc, line| {
-            acc.push("\n");
-            acc.push(line);
-            acc
-        });
-    let mut loader = std::io::Cursor::new(vec![]);
-    cpio::write_cpio(
-        vec![(
-            cpio::newc::Builder::new("nix/.nix-netboot-serve-db/register")
-                .mode(0o0100500)
-                .nlink(1),
-            std::io::Cursor::new(script.as_bytes()),
-        )]
-        .into_iter(),
-        &mut loader,
-    )
-    .map_err(LoadCpioError::Io)?;
-
-    Ok(loader.into_inner())
-}
-
-#[derive(Debug, thiserror::Error)]
-pub enum LoadCpioError {
-    #[error("A general IO error")]
-    Io(std::io::Error),
-
-    #[error("The path doesn't appear to have a base name")]
-    NoBasename(PathBuf),
-}
-
-lazy_static! {
-    pub static ref LEADER_CPIO_BYTES: Vec<u8> =
-        make_leader_cpio().expect("Failed to generate the leader CPIO.");
-    pub static ref LEADER_CPIO_LEN: u64 = LEADER_CPIO_BYTES
-        .len()
-        .try_into()
-        .expect("Failed to convert usize leader length to u64");
-}
-
-#[cfg(test)]
-mod tests {
-    use std::{
-        error::Error,
-        fs::{read_to_string, remove_file, File},
-        io::Write,
-        process::Command,
-    };
-    use tempfile::NamedTempFile;
-
-    use super::make_archive_from_dir;
-
-    #[test]
-    fn test_single_file_archive() -> Result<(), Box<dyn Error>> {
-        let mut file = NamedTempFile::new()?;
-        let archive = NamedTempFile::new()?;
-        write!(file, "Hello cpio!")?;
-        make_archive_from_dir(
-            file.path().parent().unwrap(),
-            file.path(),
-            File::create(archive.path())?,
-        )?;
-        let mut command = Command::new("sh");
-        command.args(["-c", "cpio -iv < \"$1\"", "--"]);
-        command.arg(archive.path());
-        command.current_dir(
-            archive
-                .path()
-                .parent()
-                .expect("Don't make / your tmp please"),
-        );
-        remove_file(file.path())?;
-        let out = command.output()?;
-        assert!(out.status.success());
-        let read_text = read_to_string(file.path())?;
-        assert_eq!(read_text, "Hello cpio!");
-        remove_file(archive.path())?;
-        Ok(())
+    /// This function assumes the passed PathBuf already exists in the cache.
+    pub fn new_preexisting(src: PathBuf) -> Self {
+        CachedPathBuf(src)
     }
 }

--- a/src/cpio_lru_cache.rs
+++ b/src/cpio_lru_cache.rs
@@ -1,0 +1,108 @@
+use std::path::PathBuf;
+
+use lru::LruCache;
+
+use crate::cpio::{CachedPathBuf, Cpio};
+use crate::error::CpioError;
+
+pub struct CpioLruCache {
+    pub lru_cache: LruCache<NixStorePath, Cpio>,
+    pub current_size_in_bytes: u64,
+    pub max_size_in_bytes: u64,
+}
+
+impl CpioLruCache {
+    pub fn new(max_size_in_bytes: u64) -> Self {
+        Self {
+            // NOTE: We use an unbounded LruCache because we don't care about the number of items,
+            // but the size of the items on disk (which we need to track ourselves).
+            lru_cache: LruCache::unbounded(),
+            current_size_in_bytes: 0,
+            max_size_in_bytes,
+        }
+    }
+
+    pub fn prune_single_lru(&mut self) -> Result<(), CpioError> {
+        if let Some((path, cpio)) = self.lru_cache.pop_lru() {
+            if cpio.path().exists() {
+                std::fs::remove_file(&cpio.path()).map_err(|e| CpioError::Io {
+                    ctx: "Removing the LRU CPIO",
+                    src: path.0,
+                    dest: cpio.path().to_path_buf(),
+                    e,
+                })?;
+
+                self.current_size_in_bytes -= cpio.size;
+
+                log::trace!("Removed {:?} ({} bytes)", cpio.path(), cpio.size);
+            }
+        }
+
+        Ok(())
+    }
+
+    pub fn prune_lru(&mut self) -> Result<(), CpioError> {
+        while self.current_size_in_bytes > self.max_size_in_bytes {
+            self.prune_single_lru()?;
+        }
+
+        Ok(())
+    }
+
+    pub fn push(&mut self, path: NixStorePath, cpio: Cpio) -> Result<(), CpioError> {
+        let cpio_size = cpio.size;
+
+        // Ensure we are still below (or at) the max cache size.
+        self.prune_lru()?;
+
+        // This branch is necessary, or else setting a max cache size of e.g. 0 will loop here
+        // infinitely (since the CPIOs aren't 0 bytes large, and 1 + 0 > 0).
+        if cpio_size < self.max_size_in_bytes {
+            // Ensure pushing this CPIO will not exceed the max cache size.
+            while cpio_size + self.current_size_in_bytes > self.max_size_in_bytes {
+                self.prune_single_lru()?;
+            }
+        }
+
+        if let Some((_path, replaced_cpio)) = self.lru_cache.push(path, cpio) {
+            self.current_size_in_bytes -= replaced_cpio.size;
+        }
+
+        self.current_size_in_bytes += cpio_size;
+
+        Ok(())
+    }
+
+    pub fn get(&mut self, path: &NixStorePath) -> Option<&Cpio> {
+        self.lru_cache.get(path)
+    }
+
+    pub fn demote(&mut self, path: &NixStorePath) {
+        self.lru_cache.demote(path)
+    }
+}
+
+/// A path that exists in the Nix store.
+#[derive(Debug, Hash, PartialEq, Eq)]
+pub struct NixStorePath(PathBuf);
+
+impl NixStorePath {
+    pub fn new(store_path: PathBuf) -> Self {
+        assert!(store_path.starts_with("/nix/store"));
+        NixStorePath(store_path)
+    }
+
+    pub fn from_cached(
+        cached_location: &CachedPathBuf,
+        cache_dir: &PathBuf,
+    ) -> Result<Self, CpioError> {
+        let nix_store = PathBuf::from("/nix/store");
+        let stripped = cached_location
+            .0
+            .strip_prefix(cache_dir)
+            .map_err(CpioError::StripCachePrefix)?;
+        let store_hash_path = stripped.with_extension("").with_extension("");
+
+        Ok(NixStorePath(nix_store.join(store_hash_path)))
+    }
+}

--- a/src/cpio_maker.rs
+++ b/src/cpio_maker.rs
@@ -1,0 +1,261 @@
+use std::ffi::OsString;
+use std::io::{Cursor, Write};
+use std::os::unix::ffi::OsStrExt;
+use std::os::unix::ffi::OsStringExt;
+use std::os::unix::fs::MetadataExt;
+use std::path::{Path, PathBuf};
+use std::{convert::TryInto, fs::File};
+
+use cpio::{newc, write_cpio};
+use lazy_static::lazy_static;
+use tokio::process::Command;
+use walkdir::WalkDir;
+
+use crate::files::basename;
+
+pub trait ReadSeek: std::io::Read + std::io::Seek {}
+impl<T: std::io::Read + std::io::Seek> ReadSeek for T {}
+
+#[cfg(unix)]
+pub fn make_archive_from_dir<W>(root: &Path, path: &Path, out: W) -> std::io::Result<()>
+where
+    W: Write,
+{
+    path.strip_prefix(&root).unwrap_or_else(|_| {
+        panic!("Path {:?} is not inside root ({:?})", path, &root);
+    });
+
+    let dir = WalkDir::new(path)
+        .sort_by(|a, b| a.file_name().cmp(b.file_name()))
+        .into_iter()
+        .filter_map(|entry| entry.ok())
+        .filter_map(|entry| {
+            let entry_name = entry
+                .path()
+                .strip_prefix(&root)
+                .unwrap_or_else(|_| {
+                    panic!("Path {:?} is not inside root ({:?})", entry.path(), &root)
+                })
+                .to_str()?;
+            let meta = entry.metadata().ok()?;
+            let built = newc::Builder::new(entry_name)
+                .dev_major(0)
+                .rdev_major(0)
+                .gid(1)
+                .uid(0)
+                .ino(meta.ino().try_into().ok()?)
+                .nlink(meta.nlink().try_into().ok()?)
+                .mode(meta.mode())
+                .mtime(1);
+
+            let readable_file: Box<dyn ReadSeek> = if meta.is_file() {
+                Box::new(File::open(entry.path()).ok()?)
+            } else if entry.path().is_symlink() {
+                Box::new(Cursor::new(
+                    entry
+                        .path()
+                        .read_link()
+                        .expect("TOCTTOU: is_symlink said this is a symlink")
+                        .into_os_string()
+                        .into_vec(),
+                ))
+            } else {
+                Box::new(std::io::empty())
+            };
+
+            Some((built, readable_file))
+        });
+    write_cpio(dir, out)?;
+    Ok(())
+}
+
+fn make_leader_cpio() -> std::io::Result<Vec<u8>> {
+    let mut leader_cpio = std::io::Cursor::new(vec![]);
+    cpio::write_cpio(
+        vec![
+            // mode for a directory: 0o40000 + 0o00xxx for its permission bits
+            // nlink for directories == the number of things in it plus 2 (., ..)
+            (
+                cpio::newc::Builder::new(".").mode(0o40755).nlink(3),
+                std::io::empty(),
+            ),
+            (
+                cpio::newc::Builder::new("nix").mode(0o40755).nlink(3),
+                std::io::empty(),
+            ),
+            (
+                cpio::newc::Builder::new("nix/store")
+                    .mode(0o40775)
+                    .nlink(2)
+                    .uid(0)
+                    .gid(30000),
+                std::io::empty(),
+            ),
+            (
+                cpio::newc::Builder::new("nix/.nix-netboot-serve-db")
+                    .mode(0o40755)
+                    .nlink(3),
+                std::io::empty(),
+            ),
+            (
+                cpio::newc::Builder::new("nix/.nix-netboot-serve-db/registration")
+                    .mode(0o40755)
+                    .nlink(2),
+                std::io::empty(),
+            ),
+        ]
+        .into_iter(),
+        &mut leader_cpio,
+    )?;
+
+    Ok(leader_cpio.into_inner())
+}
+
+pub async fn make_registration<W>(path: &Path, dest: &mut W) -> Result<(), MakeRegistrationError>
+where
+    W: Write,
+{
+    let out = Command::new(env!("NIX_STORE_BIN"))
+        .arg("--dump-db")
+        .arg(&path)
+        .output()
+        .await
+        .map_err(MakeRegistrationError::Exec)?;
+    if !out.status.success() {
+        return Err(MakeRegistrationError::DumpDb(out.stderr));
+    }
+
+    let filename = path
+        .file_name()
+        .ok_or(MakeRegistrationError::NoFilename)?
+        .to_str()
+        .ok_or(MakeRegistrationError::FilenameInvalidUtf8)?;
+
+    cpio::write_cpio(
+        vec![(
+            cpio::newc::Builder::new(&format!(
+                "nix/.nix-netboot-serve-db/registration/{}",
+                filename
+            ))
+            .mode(0o0100500)
+            .nlink(1),
+            std::io::Cursor::new(out.stdout),
+        )]
+        .into_iter(),
+        dest,
+    )
+    .map_err(MakeRegistrationError::Io)?;
+
+    Ok(())
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum MakeRegistrationError {
+    #[error("Executing a command failed")]
+    Exec(std::io::Error),
+
+    #[error("Generating the registration data failed")]
+    DumpDb(Vec<u8>),
+
+    #[error("An ambiguous IO error")]
+    Io(std::io::Error),
+
+    #[error("The path submitted appears to have no filename")]
+    NoFilename,
+
+    #[error(
+        "The path submitted doesn't seem to be UTF-8, even though Nix probably guarantees this"
+    )]
+    FilenameInvalidUtf8,
+}
+
+pub fn make_load_cpio(paths: &[PathBuf]) -> Result<Vec<u8>, LoadCpioError> {
+    let script = paths
+        .iter()
+        .map(|p| {
+            let mut line =
+                OsString::from("nix-store --load-db < /nix/.nix-netboot-serve-db/registration/");
+            line.push(basename(p).ok_or_else(|| LoadCpioError::NoBasename(p.to_path_buf()))?);
+            Ok(line)
+        })
+        .collect::<Result<Vec<OsString>, LoadCpioError>>()?
+        .into_iter()
+        .fold(OsString::from("#!/bin/sh"), |mut acc, line| {
+            acc.push("\n");
+            acc.push(line);
+            acc
+        });
+    let mut loader = std::io::Cursor::new(vec![]);
+    cpio::write_cpio(
+        vec![(
+            cpio::newc::Builder::new("nix/.nix-netboot-serve-db/register")
+                .mode(0o0100500)
+                .nlink(1),
+            std::io::Cursor::new(script.as_bytes()),
+        )]
+        .into_iter(),
+        &mut loader,
+    )
+    .map_err(LoadCpioError::Io)?;
+
+    Ok(loader.into_inner())
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum LoadCpioError {
+    #[error("A general IO error")]
+    Io(std::io::Error),
+
+    #[error("The path doesn't appear to have a base name")]
+    NoBasename(PathBuf),
+}
+
+lazy_static! {
+    pub static ref LEADER_CPIO_BYTES: Vec<u8> =
+        make_leader_cpio().expect("Failed to generate the leader CPIO.");
+    pub static ref LEADER_CPIO_LEN: u64 = LEADER_CPIO_BYTES
+        .len()
+        .try_into()
+        .expect("Failed to convert usize leader length to u64");
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        error::Error,
+        fs::{read_to_string, remove_file, File},
+        io::Write,
+        process::Command,
+    };
+    use tempfile::NamedTempFile;
+
+    use super::make_archive_from_dir;
+
+    #[test]
+    fn test_single_file_archive() -> Result<(), Box<dyn Error>> {
+        let mut file = NamedTempFile::new()?;
+        let archive = NamedTempFile::new()?;
+        write!(file, "Hello cpio!")?;
+        make_archive_from_dir(
+            file.path().parent().unwrap(),
+            file.path(),
+            File::create(archive.path())?,
+        )?;
+        let mut command = Command::new("sh");
+        command.args(["-c", "cpio -iv < \"$1\"", "--"]);
+        command.arg(archive.path());
+        command.current_dir(
+            archive
+                .path()
+                .parent()
+                .expect("Don't make / your tmp please"),
+        );
+        remove_file(file.path())?;
+        let out = command.output()?;
+        assert!(out.status.success());
+        let read_text = read_to_string(file.path())?;
+        assert_eq!(read_text, "Hello cpio!");
+        remove_file(archive.path())?;
+        Ok(())
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,35 @@
+use std::path::PathBuf;
+
+#[derive(Debug, thiserror::Error)]
+pub enum CpioError {
+    #[error("A filesystem error")]
+    Fs {
+        ctx: &'static str,
+        path: PathBuf,
+        #[source]
+        e: std::io::Error,
+    },
+
+    #[error("An IO error")]
+    Io {
+        ctx: &'static str,
+        src: PathBuf,
+        dest: PathBuf,
+        #[source]
+        e: std::io::Error,
+    },
+
+    #[error("Generating the Nix DB registration failed")]
+    RegistrationError(crate::cpio_maker::MakeRegistrationError),
+
+    #[error(
+        "The path we tried to generate a cache for can't turn in to a cache key for some reason"
+    )]
+    Uncachable(String),
+
+    #[error("failed to acquire a semaphore")]
+    Semaphore(tokio::sync::AcquireError),
+
+    #[error("Failed to strip cache prefix")]
+    StripCachePrefix(std::path::StripPrefixError),
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,8 @@
 mod cpio;
 pub mod cpio_cache;
+mod cpio_lru_cache;
+mod cpio_maker;
+mod error;
 mod files;
 mod nix;
 mod opened_cpio;

--- a/src/opened_cpio.rs
+++ b/src/opened_cpio.rs
@@ -4,7 +4,8 @@ use tokio::fs::File;
 use tokio::io::BufReader;
 use tokio_util::io::ReaderStream;
 
-use crate::cpio_cache::{CachedPathBuf, CpioError};
+use crate::cpio::CachedPathBuf;
+use crate::error::CpioError;
 
 pub struct OpenedCpio {
     size: u64,

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -5,8 +5,8 @@ use std::path::Path;
 
 use log::{error, info, trace, warn};
 
-use crate::cpio::{make_load_cpio, LEADER_CPIO_BYTES, LEADER_CPIO_LEN};
 use crate::cpio_cache::CpioCache;
+use crate::cpio_maker::{make_load_cpio, LEADER_CPIO_BYTES, LEADER_CPIO_LEN};
 use crate::nix::get_closure_paths;
 
 pub async fn stream(


### PR DESCRIPTION
Instead of everything being in cpio_cache, things now live in more appropriate places.

---

Based on https://github.com/DeterminateSystems/nix-cpio-generator/pull/3.
