### PR TITLE
Handle root symlinks

### DIFF
--- a/src/cpio_maker.rs
+++ b/src/cpio_maker.rs
@@ -266,7 +266,44 @@ mod tests {
     }
 
     #[test]
-    fn test_root_symlink_todirectory() -> Result<(), Box<dyn Error>> {
+    fn test_directory() -> Result<(), Box<dyn Error>> {
+        let root_handle = tempfile::tempdir().unwrap();
+
+        let root = root_handle.path();
+        let test_cpio = root.join("test.cpio");
+        let dest = root.join("dest");
+        {
+            // setup the destination
+            create_dir(&dest).unwrap();
+            write!(File::create(dest.join("a-file")).unwrap(), "hi").unwrap();
+        }
+
+        make_archive_from_dir(&root, &dest, File::create(&test_cpio).unwrap()).unwrap();
+
+        let mut cpio_handle = File::open(&test_cpio).unwrap();
+
+        let entry = cpio::newc::Reader::new(&mut cpio_handle).unwrap();
+        assert_eq!(entry.entry().name(), "dest");
+        let mut cpio_handle = entry.finish().unwrap();
+
+        let entry = cpio::newc::Reader::new(&mut cpio_handle).unwrap();
+        assert_eq!(entry.entry().name(), "dest/a-file");
+        let mut cpio_handle = entry.finish().unwrap();
+
+        let entry = cpio::newc::Reader::new(&mut cpio_handle).unwrap();
+        assert_eq!(entry.entry().name(), "TRAILER!!!");
+        let mut cpio_handle = entry.finish().unwrap();
+
+        match cpio::newc::Reader::new(&mut cpio_handle) {
+            Ok(v) => panic!("Expected an err, got an entry: {:#?}", v.entry().name()),
+            Err(_) => {}
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_root_symlink_to_directory() -> Result<(), Box<dyn Error>> {
         let root_handle = tempfile::tempdir().unwrap();
 
         let root = root_handle.path();


### PR DESCRIPTION
Given a directory structure like this:

```
/nix/store/
    path-a -> /nix/storepath-b
    path-b/foo
    path-b/bar
```

the CPIO generator would walk the target of the symlink, under  the path-a name. In other words, it'd generate a collection of entries like this:

```
/nix/store/path-a -> /nix/store/path-b
/nix/store/path-a/foo
/nix/store/path-a/bar
```

In the case that path-b has already been created on disk this might unpack okay, but if it hasn't  `/nix/store/path-a/foo` will fail to be created sync `/nix/store/path-a` is a dangling symlink to `/nix/store/path-b`.

The correct behavior is to only create the top level symlink and stop there:

```
/nix/store/path-a -> /nix/store/path-b
```

This lets the path-b archive fill in path-b's files.