### PR TITLE
DS-970: Add Magic Nix Cache and other workflow changes

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,6 +18,8 @@ jobs:
     - uses: actions/checkout@v3
     - name: Install  Nix
       uses: DeterminateSystems/nix-installer-action@main
+    - name: Enable magic Nix cache
+      uses: DeterminateSystems/magic-nix-cache-action@main
     - name: Format check
       run: cargo fmt --check
     - name: Build


### PR DESCRIPTION
 An assortment of GitHub Workflow changes, potentially including:

- Enable DeterminateSystems/magic-nix-cache-action@main
- Reference all DeterminateSystems actions via @main
- Make update.yaml consistent across repos
- Remove unnecessary github-token: from nix-installer-action
- Update actions/checkout@v2 to actions/checkout@v3
